### PR TITLE
feat: run Alembic inside App Runner container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,9 @@ name: CI / CD
 
 on:
   push:
-    branches: [ "main", "ci-cd-pipeline" ]
+    branches:
+      - main
+      - 'ci/**'
 
 permissions:
   id-token: write  # allow GitHub OIDC to assume AWS role
@@ -63,10 +65,3 @@ jobs:
         run: |
           pip install -r requirements.txt
           cdk deploy --require-approval never
-
-      - name: Run database migrations (Alembic)
-        run: |
-          pip install -r requirements.txt
-          alembic upgrade head
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+# run migrations only if flagged (avoids slowing tests)
+if [[ "${RUN_MIGRATIONS:-1}" == "1" ]]; then
+  alembic upgrade head
+fi
+exec "$@"

--- a/dockerfile
+++ b/dockerfile
@@ -32,4 +32,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY --from=assets /work/build/tailwind.css static/css/
 COPY . .
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
• Add docker-entrypoint.sh that executes `alembic upgrade head` before launching uvicorn
• Wire it in Dockerfile
• Remove remote-migration step from deploy workflow