### PR TITLE
Enforce Cognito Authentication for App Runner Deployment

### DIFF
--- a/infra/infra_stack.py
+++ b/infra/infra_stack.py
@@ -79,7 +79,10 @@ class GreatFitInfraStack(Stack):
             "WebClient",
             auth_flows=cognito.AuthFlow(user_srp=True, user_password=True),
             o_auth=cognito.OAuthSettings(
-                flows=cognito.OAuthFlows(implicit_code_grant=True),
+                flows=cognito.OAuthFlows(
+                    authorization_code_grant=True # <-- CHANGE THIS
+                    # implicit_code_grant=False # Optionally make explicit it's off
+                ),
                 scopes=[cognito.OAuthScope.OPENID, cognito.OAuthScope.EMAIL],
                 callback_urls=["https://greatfit.app/"],
                 logout_urls=["https://greatfit.app/"],

--- a/main.py
+++ b/main.py
@@ -156,7 +156,11 @@ manager = ConnectionManager()
 
 # --- Root Endpoint --- Serve index page with Jinja2 Template --- #
 @app.get("/", response_class=HTMLResponse)
-async def read_root(request: Request, settings: Settings = Depends(get_settings)):
+async def read_root(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    current_user: models.User = Depends(get_current_user) # <-- ADD THIS DEPENDENCY
+):
     """Render the main index page.
 
     Uses Jinja2 template rendering instead of serving a static file so that we

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -116,9 +116,16 @@ async function checkAuthState() {
 
 
   } catch (error) {
-    // console.log('User not authenticated via Amplify:', error);
+    console.log('User not authenticated via Amplify:', error); // Keep logging for debug
     window.currentUserId = null;
     renderAuthNav(false, true); // Render as not logged in, auth enabled
+    // *** ADD REDIRECT LOGIC HERE ***
+    // Only redirect if on the main page ('/') and auth is enabled
+    if (window.location.pathname === '/' && authEnabled) {
+        console.log("User not authenticated on main page, redirecting to login...");
+        Auth.federatedSignIn(); // Redirect to Cognito Hosted UI
+    }
+    // *** END REDIRECT LOGIC ***
   }
 
   // Clean up Cognito code from URL if present (Amplify might do this, but belt-and-suspenders)


### PR DESCRIPTION
Adds Cognito authentication to protect the FastAPI application when deployed to AWS App Runner, while preserving the existing self-hosting capability via the AUTH_BILLING_ENABLED flag.
- Enforces authentication on the root route ('/') in main.py using Depends(get_current_user).
- Implements frontend redirect in auth.js to send unauthenticated users to Cognito Hosted UI when auth is enabled.
- Corrects Cognito App Client OAuth flow in infra_stack.py to use Authorization Code Grant instead of Implicit Grant.